### PR TITLE
Fix button and post image display on square page

### DIFF
--- a/wxapp/pages/square/index.js
+++ b/wxapp/pages/square/index.js
@@ -9,10 +9,10 @@ Page({
       activeTopTab: '推荐',
   
       bottomTabs: [
-        { key: 'heart',   icon: 'like',    label: '心动' },
-        { key: 'chat',    icon: 'comment', label: '聊天' },
-        { key: 'square',  icon: 'grid',    label: '广场' },
-        { key: 'me',      icon: 'user',    label: '我的' },
+        { key: 'heart',  icon: '❤️', label: '心动' },
+        { key: 'chat',   icon: '💬', label: '聊天' },
+        { key: 'square', icon: '🔲', label: '广场' },
+        { key: 'me',     icon: '👤', label: '我的' },
       ],
       activeBottom: 'square',
   

--- a/wxapp/pages/square/index.wxml
+++ b/wxapp/pages/square/index.wxml
@@ -8,7 +8,7 @@
 >
   <!-- 菜单 -->
   <view class="icon-btn" bindtap="onMenuTap">
-    <icon type="menu" size="24" color="#444" />
+    <text class="icon-emoji">☰</text>
   </view>
 
   <!-- 选项卡 -->
@@ -28,7 +28,7 @@
 
   <!-- 搜索 -->
   <view class="icon-btn" bindtap="onSearchTap">
-    <icon type="search" size="24" color="#444" />
+    <text class="icon-emoji">🔍</text>
   </view>
 </view>
 
@@ -73,7 +73,7 @@
             <text class="author">{{item.authorName}}</text>
           </view>
           <view class="likes-row">
-            <icon type="like" size="16" color="#666" />
+            <text class="like-icon">👍</text>
             <text class="likes-text">{{item.likes}}</text>
           </view>
         </view>
@@ -90,14 +90,8 @@
       bindtap="onBottomTabTap"
       data-key="{{tab.key}}"
     >
-      <icon
-        type="{{tab.icon}}"
-        size="24"
-        color="{{activeBottom === tab.key ? '#d81e06' : '#888'}}"
-      />
-      <text
-        class="bottom-label {{activeBottom === tab.key ? 'bottom-label-active' : ''}}"
-      >{{tab.label}}</text>
+      <text class="bottom-icon" style="color:{{activeBottom === tab.key ? '#d81e06' : '#888'}}">{{tab.icon}}</text>
+      <text class="bottom-label {{activeBottom === tab.key ? 'bottom-label-active' : ''}}">{{tab.label}}</text>
     </view>
   </block>
 </view>

--- a/wxapp/pages/square/index.wxss
+++ b/wxapp/pages/square/index.wxss
@@ -7,24 +7,31 @@
   }
   
   /** 顶栏 **/
-  .top-bar {
+.top-bar {
     position: relative;
+    display: flex;
     flex-direction: row;
     align-items: center;
     padding: 0 24rpx;
     border-bottom: 1rpx solid #eee;
     z-index: 3;
   }
-  .icon-btn {
+.icon-btn {
     margin-left: 16rpx;
+  }
+
+  .icon-emoji {
+    font-size: 48rpx;
+    color: #444;
   }
   
   /** 顶部选项卡 **/
-  .top-tabs {
+.top-tabs {
     position: absolute;
     left: 60rpx;
     right: 0;
     top: 44rpx;
+    display: flex;
     flex-direction: row;
     justify-content: center;
   }
@@ -52,8 +59,9 @@
   }
   
   /** 列表内容 **/
-  .list-content {
+.list-content {
     padding: 0 16rpx;
+    display: flex;
     flex-direction: row;
     flex-wrap: wrap;
   }
@@ -71,11 +79,9 @@
   .card-even {
     margin-right: 0;
   }
-  .card-image {
+.card-image {
     width: 100%;
-    /* 高度按 1.3 比例计算 */
-    height: 0;
-    padding-top: 124%;
+    height: 390rpx;
   }
   .card-title {
     padding: 12rpx;
@@ -83,13 +89,15 @@
     line-height: 36rpx;
     color: #222;
   }
-  .card-footer {
+.card-footer {
+    display: flex;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
     padding: 0 12rpx 16rpx;
   }
-  .author-container {
+.author-container {
+    display: flex;
     flex-direction: row;
     align-items: center;
   }
@@ -103,9 +111,14 @@
     font-size: 24rpx;
     color: #666;
   }
-  .likes-row {
+.likes-row {
+    display: flex;
     flex-direction: row;
     align-items: center;
+  }
+  .like-icon {
+    font-size: 28rpx;
+    color: #666;
   }
   .likes-text {
     font-size: 24rpx;
@@ -114,20 +127,27 @@
   }
   
   /** 底部导航 **/
-  .bottom-bar {
-    position: absolute;
+.bottom-bar {
+    position: fixed;
     bottom: 0;
     left: 0;
     width: 100%;
     height: 112rpx; /* FAB_BOTTOM * 2 */
+    display: flex;
     flex-direction: row;
     background-color: #fff;
     border-top: 1rpx solid #eee;
+    z-index: 2;
   }
-  .bottom-item {
+.bottom-item {
     flex: 1;
+    display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
+  }
+  .bottom-icon {
+    font-size: 48rpx;
   }
   .bottom-label {
     font-size: 24rpx;
@@ -141,7 +161,7 @@
   
   /** 中央发帖按钮（FAB） **/
   .fab {
-    position: absolute;
+    position: fixed;
     align-self: center;
     border-radius: 56rpx; /* FAB_SIZE/2 */
     background-color: #d81e06;
@@ -149,6 +169,7 @@
     justify-content: center;
     /* 阴影 */
     box-shadow: 0 4rpx 8rpx rgba(0,0,0,0.3);
+    z-index: 3;
   }
   .plus {
     font-size: 72rpx;


### PR DESCRIPTION
## Summary
- display navigation and like buttons using emoji-based icons
- ensure post images render with a fixed height and proper flex layouts
- keep bottom navigation and FAB visible without requiring a refresh

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68958315f03c832e94d143a0bbf15ae4